### PR TITLE
Add support for event time dicts

### DIFF
--- a/pycronofy/batch.py
+++ b/pycronofy/batch.py
@@ -1,4 +1,4 @@
-from pycronofy.datetime_utils import get_iso8601_string
+from pycronofy.datetime_utils import format_event_time
 
 
 class BatchBuilder(object):
@@ -8,8 +8,8 @@ class BatchBuilder(object):
     def upsert_event(self, calendar_id, event):
         data = event.copy()
 
-        event['start'] = get_iso8601_string(event['start'])
-        event['end'] = get_iso8601_string(event['end'])
+        event['start'] = format_event_time(event['start'])
+        event['end'] = format_event_time(event['end'])
 
         self.post("/v1/calendars/%s/events" % calendar_id, data)
         return self

--- a/pycronofy/client.py
+++ b/pycronofy/client.py
@@ -6,7 +6,7 @@ from pycronofy import settings
 from pycronofy.auth import Auth
 from pycronofy.batch import BatchEntry
 from pycronofy.batch import BatchResponse
-from pycronofy.datetime_utils import get_iso8601_string
+from pycronofy.datetime_utils import format_event_time
 from pycronofy.exceptions import PyCronofyPartialSuccessError
 from pycronofy.pagination import Pages
 from pycronofy.request_handler import RequestHandler
@@ -193,8 +193,8 @@ class Client(object):
                              Accepted values are "transparent" and "opaque".
              :color        - The color of the event (optional).
         """
-        event['start'] = get_iso8601_string(event['start'])
-        event['end'] = get_iso8601_string(event['end'])
+        event['start'] = format_event_time(event['start'])
+        event['end'] = format_event_time(event['end'])
 
         body = {
             'smart_invite_id': smart_invite_id,
@@ -249,7 +249,7 @@ class Client(object):
         return {
             'access_token': self.auth.access_token,
             'refresh_token': self.auth.refresh_token,
-            'token_expiration': get_iso8601_string(self.auth.token_expiration),
+            'token_expiration': format_event_time(self.auth.token_expiration),
         }
 
     def is_authorization_expired(self):
@@ -327,9 +327,9 @@ class Client(object):
         results = self.request_handler.get(endpoint='events', params={
             'tzid': tzid,
             'calendar_ids[]': calendar_ids,
-            'from': get_iso8601_string(from_date),
-            'to': get_iso8601_string(to_date),
-            'last_modified': get_iso8601_string(last_modified),
+            'from': format_event_time(from_date),
+            'to': format_event_time(to_date),
+            'last_modified': format_event_time(last_modified),
             'only_managed': only_managed,
             'include_managed': include_managed,
             'include_deleted': include_deleted,
@@ -364,8 +364,8 @@ class Client(object):
         results = self.request_handler.get(endpoint='free_busy', params={
             'tzid': tzid,
             'calendar_ids[]': calendar_ids,
-            'from': get_iso8601_string(from_date),
-            'to': get_iso8601_string(to_date),
+            'from': format_event_time(from_date),
+            'to': format_event_time(to_date),
             'include_managed': include_managed,
             'localized_times': localized_times,
         }).json()
@@ -417,7 +417,7 @@ class Client(object):
         return {
             'access_token': self.auth.access_token,
             'refresh_token': self.auth.refresh_token,
-            'token_expiration': get_iso8601_string(self.auth.token_expiration),
+            'token_expiration': format_event_time(self.auth.token_expiration),
         }
 
     def revoke_authorization(self):
@@ -442,8 +442,8 @@ class Client(object):
         :param string calendar_id: ID of calendar to insert/update event into.
         :param dict event: Dictionary of event data to send to cronofy.
         """
-        event['start'] = get_iso8601_string(event['start'])
-        event['end'] = get_iso8601_string(event['end'])
+        event['start'] = format_event_time(event['start'])
+        event['end'] = format_event_time(event['end'])
         self.request_handler.post(
             endpoint='calendars/%s/events' % calendar_id, data=event)
 
@@ -566,7 +566,7 @@ class Client(object):
         for params in periods:
             for tp in ['start', 'end']:
                 if params[tp]:
-                    params[tp] = get_iso8601_string(params[tp])
+                    params[tp] = format_event_time(params[tp])
 
     def map_availability_participants(self, participants):
         if type(participants) is dict:

--- a/pycronofy/datetime_utils.py
+++ b/pycronofy/datetime_utils.py
@@ -7,9 +7,9 @@ ISO_8601_DATE_FORMAT = '%Y-%m-%d'
 ISO_8601_DATETIME_FORMAT = '%Y-%m-%dT%H:%M:%SZ'  # UTC
 
 
-def get_iso8601_string(date_time):
+def format_event_time(date_time):
     """
-        Accepts either an ISO 8601 string OR a datetime object.
+        Accepts either an ISO 8601 string, a dict with a time and tzid OR a datetime object.
         Must be in UTC format:
 
         2016-01-31T12:33:00Z
@@ -18,9 +18,9 @@ def get_iso8601_string(date_time):
 
         https://en.wikipedia.org/wiki/ISO_8601
 
-        :param datetime.datetime date_time: ``datetime.datetime`` or ``string``.
+        :param datetime.datetime date_time: ``datetime.datetime``, ``dict`` or ``string``.
         :return: ISO 8601 formatted datetime string.
-        :rtype: ``string``
+        :rtype: ``string`` or ``dict``
     """
     if not date_time:
         # Return None if passed None
@@ -32,9 +32,13 @@ def get_iso8601_string(date_time):
     elif date_time_type == datetime.date:
         # If passed a date, return an iso8601 formatted date string.
         return date_time.strftime(ISO_8601_DATE_FORMAT)
+    elif date_time_type is dict:
+        if date_time.get('time'):
+            date_time['time'] = format_event_time(date_time['time'])
+        return date_time
     elif date_time_type != datetime.datetime:
-        # If passed anything other than a datetime, date, string, or None, raise an Exception.
-        error_message = 'Unsupported type: ``%s``.\nSupported types: ``<datetime.datetime>``, ``<datetime.date>``, or ``<str>``.'
+        # If passed anything other than a datetime, date, string, dict, or None, raise an Exception.
+        error_message = 'Unsupported type: ``%s``.\nSupported types: ``<datetime.datetime>``, ``<datetime.date>``, ``<dict>``, or ``<str>``.'
         raise PyCronofyDateTimeError(
             error_message % (repr(type(date_time))), date_time)
     if date_time.tzinfo and date_time.tzinfo != pytz.utc:

--- a/pycronofy/exceptions.py
+++ b/pycronofy/exceptions.py
@@ -4,7 +4,7 @@ class PyCronofyDateTimeError(Exception):
     def __init__(self, message, argument):
         """
         :param string message: Exception message.
-        :param object argument: Value passed into get_iso8601_string.
+        :param object argument: Value passed into format_event_time.
         """
         super(PyCronofyDateTimeError, self).__init__(message)
         self.argument = argument

--- a/pycronofy/tests/test_client.py
+++ b/pycronofy/tests/test_client.py
@@ -429,6 +429,47 @@ def test_upsert_event(client):
 
 
 @responses.activate
+def test_upsert_event_with_tzid(client):
+    """Test Client.upsert_event().
+
+    :param Client client: Client instance with test data.
+    """
+
+    def request_callback(request):
+        payload = json.loads(request.body)
+        assert payload == test_event
+
+        return (202, {}, None)
+
+    test_event = {
+        'event_id': 'test-1',
+        'summary': 'Test Event',
+        'description': 'Talk about how awesome cats are.',
+        'start': {
+            'time': '2014-10-01T08:00:00Z',
+            'tzid': 'Europe/London'
+        },
+        'end': {
+            'time': '2014-10-01T09:00:00Z',
+            'tzid': 'Europe/London'
+        },
+        'location': {
+            'description': 'Location!',
+        }
+    }
+
+    responses.add_callback(
+        responses.POST,
+        '%s/%s/calendars/1/events' % (settings.API_BASE_URL, settings.API_VERSION),
+        callback=request_callback,
+        content_type='application/json',
+    )
+
+    response = client.upsert_event('1', test_event)
+    assert response is None
+
+
+@responses.activate
 def test_upsert_smart_invtes(client):
     url = "http://www.example.com"
     smart_invite_id = "qTtZdczOccgaPncGJaCiLg"

--- a/pycronofy/tests/test_datetime_utils.py
+++ b/pycronofy/tests/test_datetime_utils.py
@@ -1,42 +1,62 @@
 import datetime
 import pytest
 import pytz
-from pycronofy.datetime_utils import get_iso8601_string
+from pycronofy.datetime_utils import format_event_time
 
 
 def test_date():
-    """Test get_iso8601_string returns an ISO8601 formatted date string when passed a datetime.date object"""
-    assert get_iso8601_string(datetime.date(2016, 1, 15)) == '2016-01-15'
+    """Test format_event_time returns an ISO8601 formatted date string when passed a datetime.date object"""
+    assert format_event_time(datetime.date(2016, 1, 15)) == '2016-01-15'
+
+
+def test_date_nested_in_dict():
+    """Test format_event_time returns an ISO8601 formatted date string in a dict when passed a datetime.date object"""
+    date = datetime.date(2016, 1, 15)
+    params = {
+        'time': date,
+        'tzid': 'Etc/UTC',
+    }
+    assert format_event_time(params) == {'time': '2016-01-15', 'tzid': 'Etc/UTC'}
+
+
+def test_iso8601_string_in_dict():
+    """Test format_event_time returns an ISO8601 formatted date string in a dict when passed a datetime.date object"""
+    date = '2016-01-15'
+    params = {
+        'time': date,
+        'tzid': 'Etc/UTC',
+    }
+    assert format_event_time(params) == {'time': '2016-01-15', 'tzid': 'Etc/UTC'}
 
 
 def test_datetime():
-    """Test get_iso8601_string returns an ISO8601 formatted datetime string when passed a datetime.date object,
+    """Test format_event_time returns an ISO8601 formatted datetime string when passed a datetime.date object,
     and throws an exception when tzinfo is not set."""
     target_datetime = '2016-01-15T09:08:00'
     d = datetime.datetime.strptime(target_datetime, '%Y-%m-%dT%H:%M:%S')
-    assert get_iso8601_string(d) == ('%sZ' % target_datetime)
+    assert format_event_time(d) == ('%sZ' % target_datetime)
 
 
 def test_iso8601_string():
-    """Test get_iso8601_string returns a string when passed a string"""
-    assert get_iso8601_string('2016-01-15') == '2016-01-15'
+    """Test format_event_time returns a string when passed a string"""
+    assert format_event_time('2016-01-15') == '2016-01-15'
 
 
 def test_none():
-    """Test get_iso8601_string returns None when passed None"""
-    assert get_iso8601_string(None) is None
+    """Test format_event_time returns None when passed None"""
+    assert format_event_time(None) is None
 
 
 def test_tz_aware_datetime():
-    """Test get_iso8601_string returns an ISO8601 formatted datetime string with UTC timezone
+    """Test format_event_time returns an ISO8601 formatted datetime string with UTC timezone
     when passed a datetime.date object that's set to another timezone."""
     d = datetime.datetime(2016, 1, 15, 14, 20, 15, tzinfo=pytz.timezone('EST'))
-    assert get_iso8601_string(d) == '2016-01-15T19:20:15Z'
+    assert format_event_time(d) == '2016-01-15T19:20:15Z'
 
 
 def test_unsupported():
-    """Test get_iso8601_string throws an exception when passed an unsupported type"""
+    """Test format_event_time throws an exception when passed an unsupported type"""
     with pytest.raises(Exception) as exception_info:
-        get_iso8601_string(1)
-    assert exception_info.value.message == 'Unsupported type: ``%s``.\nSupported types: ``<datetime.datetime>``, ``<datetime.date>``, or ``<str>``.' % repr(type(1))
+        format_event_time(1)
+    assert exception_info.value.message == 'Unsupported type: ``%s``.\nSupported types: ``<datetime.datetime>``, ``<datetime.date>``, ``<dict>``, or ``<str>``.' % repr(type(1))
     assert exception_info.value.argument == 1

--- a/pycronofy/tests/test_datetime_utils.py
+++ b/pycronofy/tests/test_datetime_utils.py
@@ -20,13 +20,23 @@ def test_date_nested_in_dict():
 
 
 def test_iso8601_string_in_dict():
-    """Test format_event_time returns an ISO8601 formatted date string in a dict when passed a datetime.date object"""
+    """Test format_event_time returns an ISO8601 formatted date string in a dict when passed a iso8601 string"""
     date = '2016-01-15'
     params = {
         'time': date,
         'tzid': 'Etc/UTC',
     }
     assert format_event_time(params) == {'time': '2016-01-15', 'tzid': 'Etc/UTC'}
+
+
+def test_tz_aware_datetime_in_dict():
+    """Test format_event_time returns an ISO8601 formatted date string in a dict when passed a datetimee object"""
+    date = datetime.datetime(2016, 1, 15, 14, 20, 15, tzinfo=pytz.timezone('EST'))
+    params = {
+        'time': date,
+        'tzid': 'Etc/UTC',
+    }
+    assert format_event_time(params) == {'time': '2016-01-15T19:20:15Z', 'tzid': 'Etc/UTC'}
 
 
 def test_datetime():


### PR DESCRIPTION
For example passing event start as a value of `{ 'time': '2016-01-01', 'tzid': 'Etc/UTC' }` will no longer raise an error and will automatically format any nested date types contained within the dict

Fixes #5 