### PR TITLE
Update auth.py

### DIFF
--- a/pycronofy/auth.py
+++ b/pycronofy/auth.py
@@ -18,7 +18,7 @@ class Auth(object):
         self.client_secret = client_secret
         self.access_token = access_token
         self.refresh_token = refresh_token
-        self.token_expiration = None
+        self.token_expiration = token_expiration
         self.redirect_uri = ''
 
     def get_authorization(self):


### PR DESCRIPTION
`token_expiration` field seems to always be set to `None` no matter what the user supplies as parameter.

I have made an adjustment to the constructor so that the `token_expiration` follows the same pattern as that of the rest of the optional arguments.