### PR TITLE
Token expiry timezone awareness

### DIFF
--- a/pycronofy/auth.py
+++ b/pycronofy/auth.py
@@ -11,7 +11,7 @@ class Auth(object):
         :param string client_secret: OAuth Client Secret. (Optional, default None)
         :param string access_token: Access Token for User's Account. (Optional, default None)
         :param string refresh_token: Existing Refresh Token for User's Account. (Optional, default None)
-        :param string token_expiration: Datetime token expires. (Optional, default None)
+        :param datetime.datetime token_expiration: Datetime token expires. (Optional, default None)
         :param bool settings.DEBUG: Instantiate in debug mode. (Optional, default False).
         """
         self.client_id = client_id

--- a/pycronofy/client.py
+++ b/pycronofy/client.py
@@ -1,5 +1,7 @@
 import datetime
 import collections
+
+import pytz
 from future.standard_library import hooks
 
 from pycronofy import settings
@@ -32,7 +34,7 @@ class Client(object):
         :param string client_secret: OAuth Client Secret. (Optional, default None)
         :param string access_token: Access Token for User's Account. (Optional, default None)
         :param string refresh_token: Existing Refresh Token for User's Account. (Optional, default None)
-        :param string token_expiration: Datetime token expires. (Optional, default None)
+        :param datetime.datetime token_expiration: Datetime token expires. (Optional, default None)
         :param string data_center: The name of the data_center to use. (Optional, default None)
         """
         self.auth = Auth(client_id, client_secret, access_token,
@@ -255,7 +257,7 @@ class Client(object):
                 'redirect_uri': redirect_uri if redirect_uri else self.auth.redirect_uri,
             })
         data = response.json()
-        token_expiration = (datetime.datetime.utcnow() + datetime.timedelta(seconds=data['expires_in']))
+        token_expiration = (datetime.datetime.now(tz=pytz.utc) + datetime.timedelta(seconds=data['expires_in']))
         self.auth.update(
             token_expiration=token_expiration,
             access_token=data['access_token'],
@@ -282,7 +284,7 @@ class Client(object):
                 'application_calendar_id': application_calendar_id,
             })
         data = response.json()
-        token_expiration = (datetime.datetime.utcnow() + datetime.timedelta(seconds=data['expires_in']))
+        token_expiration = (datetime.datetime.now(tz=pytz.utc) + datetime.timedelta(seconds=data['expires_in']))
         self.auth.update(
             token_expiration=token_expiration,
             access_token=data['access_token'],
@@ -304,7 +306,7 @@ class Client(object):
         """
         if not self.auth.token_expiration:
             return True
-        return (datetime.datetime.utcnow() > self.auth.token_expiration)
+        return datetime.datetime.now(tz=pytz.utc) > self.auth.token_expiration
 
     def list_calendars(self):
         """Return a list of calendars available for the active account.
@@ -492,7 +494,7 @@ class Client(object):
             }
         )
         data = response.json()
-        token_expiration = (datetime.datetime.utcnow() + datetime.timedelta(seconds=data['expires_in']))
+        token_expiration = (datetime.datetime.now(tz=pytz.utc) + datetime.timedelta(seconds=data['expires_in']))
         self.auth.update(
             token_expiration=token_expiration,
             access_token=data['access_token'],

--- a/pycronofy/tests/test_client.py
+++ b/pycronofy/tests/test_client.py
@@ -1,6 +1,7 @@
 import datetime
 import json
 import pytest
+import pytz
 import responses
 from pycronofy import Client
 from pycronofy import settings
@@ -230,9 +231,9 @@ def test_is_authorization_expired(client):
 
     :param Client client: Client instance with test data.
     """
-    client.auth.token_expiration = datetime.datetime.utcnow() + datetime.timedelta(seconds=60)
+    client.auth.token_expiration = datetime.datetime.now(tz=pytz.utc) + datetime.timedelta(seconds=60)
     assert client.is_authorization_expired() is False
-    client.auth.token_expiration = datetime.datetime.utcnow() - datetime.timedelta(seconds=60)
+    client.auth.token_expiration = datetime.datetime.now(tz=pytz.utc) - datetime.timedelta(seconds=60)
     assert client.is_authorization_expired() is True
 
 


### PR DESCRIPTION
This PR makes token expiry datetimes (and comparison thereof) timezone-aware.

Currently, token expiry datetimes are created as naive datetimes. When storing these objects with an ORM such as Django, by default they come back as aware (which arguably makes more sense). Creating an Auth object with these aware datetimes causes type errors, since pycronofy compares those to `datetime.datetime.utcnow()` (naive). This wasn't an issue until #48 merged, since user-provided token_expirations were just ignored before then. 

Separately, I updated the expected type for `token_expiration` in the Auth/Client constructor's docstring from string to datetime, since that's what it expects. 

Does this make sense, and is this a reasonable change? 