### PR TITLE
Adds `provider_name` optional param to `user_auth_link()`

### DIFF
--- a/pycronofy/client.py
+++ b/pycronofy/client.py
@@ -664,13 +664,14 @@ class Client(object):
 
         return self.request_handler.post(endpoint='real_time_sequencing', data=args, use_api_key=True).json()
 
-    def user_auth_link(self, redirect_uri, scope='', state='', avoid_linking=False):
+    def user_auth_link(self, redirect_uri, scope='', state='', provider_name='', avoid_linking=False):
         """Generates a URL to send the user for OAuth 2.0
 
         :param string redirect_uri: URL to redirect the user to after auth.
         :param string scope: The scope of the privileges you want the eventual access_token to grant.
         :param string state: A value that will be returned to you unaltered along with the user's authorization request decision.
         (The OAuth 2.0 RFC recommends using this to prevent cross-site request forgery.)
+        :param string provider_name: A value indicating a calendar service provider to pre-select for the user.
         :param bool avoid_linking: Avoid linking calendar accounts together under one set of credentials. (Optional, default: false).
         :return: authorization link
         :rtype: ``string``
@@ -687,6 +688,7 @@ class Client(object):
             'redirect_uri': redirect_uri,
             'scope': scope,
             'state': state,
+            'provider_name': provider_name,
             'avoid_linking': avoid_linking,
         }
         urlencoded_params = urlencode(params)


### PR DESCRIPTION
The API supports a `provider_name` param, e.g. `provider_name=google`, to pre-select a service for the user. This is missing from PyCronofy, and this PR adds it.

It might have been better to add kwargs here, or merge an optional params dict, so that future API params were also supported. But that doesn't seem to be a common pattern in this lib, so I didn't. I also noticed that `locale` is not supported, but perhaps should be.