### PR TITLE
Revoke with refresh token

### DIFF
--- a/pycronofy/client.py
+++ b/pycronofy/client.py
@@ -540,7 +540,7 @@ class Client(object):
             data={
                 'client_id': self.auth.client_id,
                 'client_secret': self.auth.client_secret,
-                'token': self.auth.access_token,
+                'token': self.auth.refresh_token,
             }
         )
         self.auth.update(

--- a/pycronofy/validation.py
+++ b/pycronofy/validation.py
@@ -70,7 +70,7 @@ METHOD_RULES = {
     },
     'revoke_authorization': {
         'args': (),
-        'auth': ('client_id', 'client_secret', 'access_token'),
+        'auth': ('client_id', 'client_secret', 'refresh_token'),
     },
     'revoke_profile': {
         'args': ('profile_id',),


### PR DESCRIPTION
Resolves #59
Use `refresh_token` to revoke authorization as documentation recommended.