### PR TITLE
Add missing comments for smart invite

### DIFF
--- a/pycronofy/client.py
+++ b/pycronofy/client.py
@@ -207,6 +207,7 @@ class Client(object):
              :color        - The color of the event (optional).
         :param dict organizer - A Dict containing the organzier of the invite
              :name      - A String for the name of the organizer.
+             :email     - A String for the email address of the organizer.
         """
         event['start'] = format_event_time(event['start'])
         event['end'] = format_event_time(event['end'])


### PR DESCRIPTION
This comment is crucial to users, without `email` value in `organizer`, the host won't be able to receive user's RSVP result.