### PR TITLE
Support Python up to 3.12, drop 2.x.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:
-          python-version: "${{ matrix.python-version }}"
+          python-version: ${{ matrix.python-version }}
           
       - uses: actions/cache@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9","3.10","3.11"]
+        python-version: ["3.7", "3.8", "3.9","3.10","3.11"]
       
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9","3.10","3.11"]
+        python-version: ["3.7","3.8","3.9","3.10","3.11"]
       
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.9,3.10,3.11]
+        python-version: ["3.9","3.10","3.11"]
       
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [2.7,3.7,3.8,3.9]
+        python-version: [3.9,3.10,3.11]
       
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "${{ matrix.python-version }}"
           
       - uses: actions/cache@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7","3.8","3.9","3.10","3.11"]
+        python-version: ["3.7","3.8","3.9","3.10","3.11","3.12"]
       
     steps:
       - uses: actions/checkout@v2

--- a/pycronofy/client.py
+++ b/pycronofy/client.py
@@ -6,7 +6,6 @@ import base64
 import hmac
 
 import pytz
-from future.standard_library import hooks
 
 from pycronofy import settings
 from pycronofy.auth import Auth
@@ -18,8 +17,7 @@ from pycronofy.pagination import Pages
 from pycronofy.request_handler import RequestHandler
 from pycronofy.validation import validate
 
-with hooks():
-    from urllib.parse import urlencode
+from urllib.parse import urlencode
 
 
 class Client(object):

--- a/pycronofy/client.py
+++ b/pycronofy/client.py
@@ -1,5 +1,5 @@
 import datetime
-import collections
+import collections.abc
 
 import hashlib
 import base64
@@ -808,7 +808,7 @@ class Client(object):
                     params[tp] = format_event_time(params[tp])
 
     def map_availability_sequence(self, sequence):
-        if isinstance(sequence, collections.Iterable):
+        if isinstance(sequence, collections.abc.Iterable):
             return list(map(lambda item: self.map_sequence_item(item), sequence))
         else:
             return sequence
@@ -856,7 +856,7 @@ class Client(object):
         if type(participants) is dict:
             # Allow one group to be specified without being nested
             return [self.map_availability_participants_group(participants)]
-        elif isinstance(participants, collections.Iterable):
+        elif isinstance(participants, collections.abc.Iterable):
             return list(map(lambda group: self.map_availability_participants_group(group), participants))
         else:
             return participants
@@ -870,7 +870,7 @@ class Client(object):
                 participants['required'] = 'all'
 
             return participants
-        elif isinstance(participants, collections.Iterable):
+        elif isinstance(participants, collections.abc.Iterable):
             return list(map(lambda group: self.map_availability_participants(group), participants))
         else:
             participants

--- a/pycronofy/tests/test_availability.py
+++ b/pycronofy/tests/test_availability.py
@@ -308,7 +308,7 @@ def test_availablity_with_fully_specified_options(client):
     }
 
     result = client.availability(required_duration={'minutes': 30}, available_periods=periods, participants=example_participants, buffer=example_buffer)
-    assert(len(result)) == 1
+    assert len(result) == 1
 
 
 @responses.activate

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -1,6 +1,5 @@
 requests>=2.21.0
 pytz>=2018.9
-future
 
 pytest
 pytest-cov

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ requests>=2.21.0
 pytz>=2018.9
 future
 
-pytest==6.2.4
-pytest-cov==2.12.1
-responses==0.5.0
+pytest
+pytest-cov
+responses
 flake8

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,7 @@
 requests>=2.21.0
 pytz>=2018.9
-future
 
-pytest
-pytest-cov
-responses
+pytest>=6.2.4
+pytest-cov>=2.12.1
+responses>=0.5.0
 flake8

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,5 @@ setup(
     install_requires=[
         "requests>=2.20.0",
         "pytz>=2013.7",
-        "future",
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox:tox]
-envlist = py{3.9,3.10,3.11}
+envlist = py{3.7,3.8,3.9,3.10,3.11}
 
 [flake8]
 exclude = .tox,./build
@@ -8,6 +8,8 @@ ignore = E501 E721
 
 [testenv]
 basepython =
+    py3.7: python3.7
+    py3.8: python3.8
     py3.9: python3.9
     py3.10: python3.10
     py3.11: python3.11

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,15 @@
+[tox:tox]
+envlist = py{3.9,3.10,3.11}
+
 [flake8]
 exclude = .tox,./build
 filename = *.py
 ignore = E501
+
+[testenv]
+basepython =
+    py3.9: python3.9
+    py3.10: python3.10
+    py3.11: python3.11
+commands = pytest
+deps = -rrequirements.txt

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist = py{3.9,3.10,3.11}
 [flake8]
 exclude = .tox,./build
 filename = *.py
-ignore = E501
+ignore = E501 E721
 
 [testenv]
 basepython =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox:tox]
-envlist = py{3.7,3.8,3.9,3.10,3.11}
+envlist = py{3.7,3.8,3.9,3.10,3.11,3.12}
 
 [flake8]
 exclude = .tox,./build
@@ -13,5 +13,6 @@ basepython =
     py3.9: python3.9
     py3.10: python3.10
     py3.11: python3.11
+    py3.12: python3.12
 commands = pytest
 deps = -rrequirements.txt


### PR DESCRIPTION
Make the library compatible with Python up to 3.12.

2.7 should no longer be used, it's been almost 4 years since the end of security support, this PR drops the 2/3 compatibility layer.  If anyone really needs to, they can use an older version of the library.
