### PR TITLE
Add ability to authorise a batch of accounts using a service account

### DIFF
--- a/pycronofy/client.py
+++ b/pycronofy/client.py
@@ -493,7 +493,7 @@ class Client(object):
 
         :rtype: ``list``
         """
-        options = {}
+        options = dict()
         options['sequence'] = self.map_availability_sequence(sequence)
 
         self.translate_available_periods(available_periods)
@@ -584,6 +584,20 @@ class Client(object):
 
         if state is not None:
             params['state'] = state
+
+        self.request_handler.post(
+            endpoint="service_account_authorizations", data=params)
+        None
+
+    def authorize_batch_with_service_account(self, service_account_authorizations):
+        """ Attempts to authorize a batch of emails with impersonation from a service account
+
+        :param string authorizations: A batch of 1 to 50 access requests.
+        :return: nothing
+        """
+        params = {
+            "service_account_authorizations": service_account_authorizations
+        }
 
         self.request_handler.post(
             endpoint="service_account_authorizations", data=params)
@@ -721,7 +735,7 @@ class Client(object):
         :param dict event:     - A dict describing the event
         :param list target_calendars: - An list of dics stating into which calendars
                                         to insert the created event
-        :param dict :minimum_notice - A dict describing the minimum notice for a booking (Optional)
+        :param dict, optional :minimum_notice - A dict describing the minimum notice for a booking (Optional)
 
         See https://docs.cronofy.com/developers/api-alpha/sequenced-scheduling/real-time-sequencing/ for reference.
         """
@@ -732,7 +746,7 @@ class Client(object):
         }
 
         if availability:
-            options = {}
+            options = dict()
             options['sequence'] = self.map_availability_sequence(availability.get('sequence', None))
 
             if availability.get('available_periods', None):

--- a/pycronofy/tests/test_client.py
+++ b/pycronofy/tests/test_client.py
@@ -3,6 +3,7 @@ import json
 import pytest
 import pytz
 import responses
+from functools import partial
 from pycronofy import Client
 from pycronofy import settings
 from pycronofy.exceptions import PyCronofyRequestError
@@ -763,7 +764,72 @@ def test_authorize_with_service_account(client):
         callback=request_callback,
         content_type='application/json',
     )
-    client.authorize_with_service_account("example@example.com", "felines", "http://www.example.com/callback", state="state example")
+    client.authorize_with_service_account(
+        "example@example.com",
+        "felines",
+        "http://www.example.com/callback",
+        state="state example"
+    )
+
+
+@responses.activate
+def test_authorize_batch_with_service_account(client):
+    """Test authorize_batch_with_service_account with correct data
+    :param Client client: Client instance with test data.
+    """
+
+    def request_callback(request, email, scope, state, callback_url):
+        request_body = json.loads(request.body)
+
+        assert request_body['service_account_authorizations'] != []
+
+        service_account_authorizations = request_body['service_account_authorizations']
+        for payload in service_account_authorizations:
+            assert payload['email'] == email
+            assert payload['scope'] == scope
+            assert payload['state'] == state
+            assert payload['callback_url'] == callback_url
+
+            return (202, {}, None)
+
+    payloads = [
+        {
+            'email': 'example+1@example.com',
+            'scope': 'felines',
+            'state': 'state example',
+            'callback_url': 'http://www.example.com/callback'
+        },
+        {
+            'email': 'example+2@example.com',
+            'scope': 'felines',
+            'state': 'state example',
+            'callback_url': 'http://www.example.com/callback'
+        },
+        {
+            'email': 'example+3@example.com',
+            'scope': 'felines',
+            'state': 'state example',
+            'callback_url': 'http://www.example.com/callback'
+        }
+    ]
+
+    for data in payloads:
+        responses.add_callback(
+            responses.POST,
+            '%s/v1/service_account_authorizations' % settings.API_BASE_URL,
+            callback=partial(
+                request_callback,
+                email=data['email'],
+                scope=data['scope'],
+                callback_url=data['callback_url'],
+                state=data['state']
+            ),
+            content_type='application/json',
+        )
+
+    client.authorize_batch_with_service_account(
+        service_account_authorizations=payloads
+    )
 
 
 @responses.activate


### PR DESCRIPTION
Adds a new `authorize_batch_with_service_account` method to the client which invokes the [batch enterprise connect authorise endpoint](https://docs.cronofy.com/developers/api/enterprise-connect/delegated-access/#example-request-for-a-collection-of-email-addresses).