### PR TITLE
Support for `callback_urls` param for Real Time Scheduling

### DIFF
--- a/pycronofy/client.py
+++ b/pycronofy/client.py
@@ -608,7 +608,7 @@ class Client(object):
             endpoint="service_account_authorizations", data=params)
         None
 
-    def real_time_scheduling(self, availability, oauth, event, target_calendars=(), minimum_notice=None, callback_url=None, redirect_urls=None):
+    def real_time_scheduling(self, availability, oauth, event, target_calendars=(), minimum_notice=None, callback_url=None, callback_urls=None, redirect_urls=None):
         """Generates an real time scheduling link to start the OAuth process with
         an event to be automatically upserted
 
@@ -633,11 +633,13 @@ class Client(object):
         :param dict :minimum_notice - A dict describing the minimum notice for a booking (Optional)
         (DEPRECATED) :param string :callback_url - A String representing the URL Cronofy will notify
                                       once a slot has been selected.
-        :param dict callback_url: - A dict containing redirect URLs for the end-user's journey
-            :completed_url         - A String representing the URL the end-user
-                                     will be redirected to after choosing a slot
-            :no_times_suitable_url - A String representing the URL the end-user
-                                     will be redirected if there is no available slots
+        :param dict callback_urls: - A dict containing the callback URLs Cronofy will notify for each event
+            :completed_url         - A String representing the URL to call when a slot
+                                     has been chosen and the full event details are known
+            :no_times_suitable_url - A String representing the URL to call when the user
+                                     indicates that none of the available times are suitable for them
+            :no_times_displayed_url - A String representing the URL to call when the user
+                                     was shown a page with no available times
         :param dict redirect_urls: - A dict containing redirect URLs for the end-user's journey
             :completed_url         - A String representing the URL the end-user
                                      will be redirected to after choosing a slot
@@ -665,6 +667,9 @@ class Client(object):
 
         if callback_url:
             args['callback_url'] = callback_url
+
+        if callback_urls:
+            args['callback_urls'] = callback_urls
 
         if redirect_urls:
             args['redirect_urls'] = redirect_urls

--- a/pycronofy/tests/test_real_time_scheduling.py
+++ b/pycronofy/tests/test_real_time_scheduling.py
@@ -121,7 +121,7 @@ def test_real_time_scheduling(client):
 
 
 @responses.activate
-def test_real_time_scheduling_when_callback_url_is_dictionary(client):
+def test_real_time_scheduling_when_callback_urls_is_dictionary(client):
     """Test Client.availability().
 
     :param Client client: Client instance with test data.
@@ -153,8 +153,9 @@ def test_real_time_scheduling_when_callback_url_is_dictionary(client):
         assert payload['oauth'] == oauth
         assert payload['minimum_notice'] == {'hours': 4}
 
-        assert payload['callback_url']['completed_url'] == 'http://www.example.com/callback'
-        assert payload['callback_url']['completed_url'] == 'http://www.example.com/callback'
+        assert payload['callback_urls']['completed_url'] == 'http://www.example.com/completed_callback'
+        assert payload['callback_urls']['no_times_suitable_url'] == 'http://www.example.com/no_times_suitable_url_callback'
+        assert payload['callback_urls']['no_times_displayed_url'] == 'http://www.example.com/no_times_displayed_url_callback'
 
         assert payload['redirect_urls']['completed_url'] == 'http://www.example.com/completed'
 
@@ -201,16 +202,17 @@ def test_real_time_scheduling_when_callback_url_is_dictionary(client):
         'hours': 4
     }
 
-    callback_url = {
-        'completed_url': 'http://www.example.com/callback',
-        'no_times_suitable_url': 'http://www.example.com/callback'
+    callback_urls = {
+        'completed_url': 'http://www.example.com/completed_callback',
+        'no_times_suitable_url': 'http://www.example.com/no_times_suitable_url_callback',
+        'no_times_displayed_url': 'http://www.example.com/no_times_displayed_url_callback'
     }
 
     redirect_urls = {
         'completed_url': 'http://www.example.com/completed'
     }
 
-    result = client.real_time_scheduling(availability, oauth, TEST_EVENT, [], minimum_notice, callback_url=callback_url, redirect_urls=redirect_urls)
+    result = client.real_time_scheduling(availability, oauth, TEST_EVENT, [], minimum_notice, callback_urls=callback_urls, redirect_urls=redirect_urls)
     assert result == REAL_TIME_SCHEDULING_RESPONSE
 
 


### PR DESCRIPTION
As defined in [the docs](https://docs.cronofy.com/developers/api/scheduling/real-time-scheduling/#param-callback_url), `callback_url` was deprecated in favour of a dictionary of `callback_urls`.