### PR TITLE
RTS support for `event_creation`

### DIFF
--- a/pycronofy/client.py
+++ b/pycronofy/client.py
@@ -654,7 +654,7 @@ class Client(object):
                                      will be redirected to after choosing a slot
         :param string event_creation: - A string to determine behaviour of event creation.
                                         The value of 'single' will create the resulting event in a single
-                                        calendar. 'default' if omitted, creates an event in each calendar
+                                        calendar. 'default' or omitted, creates an event in each calendar
                                         listed in target_calendars. See docs for more details. (Optional)
 
         See https://docs.cronofy.com/developers/api/scheduling/real-time-scheduling/ for reference.

--- a/pycronofy/client.py
+++ b/pycronofy/client.py
@@ -608,7 +608,16 @@ class Client(object):
             endpoint="service_account_authorizations", data=params)
         None
 
-    def real_time_scheduling(self, availability, oauth, event, target_calendars=(), minimum_notice=None, callback_url=None, callback_urls=None, redirect_urls=None):
+    def real_time_scheduling(self,
+                             availability,
+                             oauth,
+                             event,
+                             target_calendars=(),
+                             minimum_notice=None,
+                             callback_url=None,
+                             callback_urls=None,
+                             redirect_urls=None,
+                             event_creation=None):
         """Generates an real time scheduling link to start the OAuth process with
         an event to be automatically upserted
 
@@ -643,6 +652,10 @@ class Client(object):
         :param dict redirect_urls: - A dict containing redirect URLs for the end-user's journey
             :completed_url         - A String representing the URL the end-user
                                      will be redirected to after choosing a slot
+        :param string event_creation: - A string to determine behaviour of event creation.
+                                        The value of 'single' will create the resulting event in a single
+                                        calendar. 'default' if omitted, creates an event in each calendar
+                                        listed in target_calendars. See docs for more details. (Optional)
 
         See https://docs.cronofy.com/developers/api/scheduling/real-time-scheduling/ for reference.
         """
@@ -673,6 +686,9 @@ class Client(object):
 
         if redirect_urls:
             args['redirect_urls'] = redirect_urls
+
+        if event_creation:
+            args['event_creation'] = event_creation
 
         return self.request_handler.post(endpoint='real_time_scheduling', data=args, use_api_key=True).json()
 

--- a/pycronofy/tests/test_real_time_scheduling.py
+++ b/pycronofy/tests/test_real_time_scheduling.py
@@ -67,6 +67,8 @@ def test_real_time_scheduling(client):
         assert payload['callback_url'] == 'http://www.example.com/callback'
         assert payload['redirect_urls']['completed_url'] == 'http://www.example.com/completed'
 
+        assert payload['event_creation'] == "single"
+
         assert request.headers['Authorization'] == "Bearer %s" % client.auth.client_secret
 
         return (200, {}, json.dumps(REAL_TIME_SCHEDULING_RESPONSE))
@@ -116,7 +118,9 @@ def test_real_time_scheduling(client):
         'completed_url': 'http://www.example.com/completed'
     }
 
-    result = client.real_time_scheduling(availability, oauth, TEST_EVENT, [], minimum_notice, callback_url=callback_url, redirect_urls=redirect_urls)
+    event_creation = "single"
+
+    result = client.real_time_scheduling(availability, oauth, TEST_EVENT, [], minimum_notice, callback_url=callback_url, redirect_urls=redirect_urls, event_creation=event_creation)
     assert result == REAL_TIME_SCHEDULING_RESPONSE
 
 

--- a/pycronofy/tests/test_real_time_scheduling.py
+++ b/pycronofy/tests/test_real_time_scheduling.py
@@ -67,8 +67,6 @@ def test_real_time_scheduling(client):
         assert payload['callback_url'] == 'http://www.example.com/callback'
         assert payload['redirect_urls']['completed_url'] == 'http://www.example.com/completed'
 
-        assert payload['event_creation'] == "single"
-
         assert request.headers['Authorization'] == "Bearer %s" % client.auth.client_secret
 
         return (200, {}, json.dumps(REAL_TIME_SCHEDULING_RESPONSE))
@@ -118,9 +116,159 @@ def test_real_time_scheduling(client):
         'completed_url': 'http://www.example.com/completed'
     }
 
+    result = client.real_time_scheduling(availability, oauth, TEST_EVENT, [], minimum_notice, callback_url=callback_url, redirect_urls=redirect_urls)
+    assert result == REAL_TIME_SCHEDULING_RESPONSE
+
+
+@responses.activate
+def test_real_time_scheduling_with_target_calendars(client):
+    """Test Client.availability().
+
+    :param Client client: Client instance with test data.
+    """
+
+    def request_callback(request):
+        payload = json.loads(request.body)
+
+        availability = payload['availability']
+        assert availability['required_duration'] == {'minutes': 30}
+        assert availability['start_interval'] == {'minutes': 30}
+        assert availability['buffer']['before'] == {'minutes': 30}
+        assert availability['buffer']['after'] == {'minutes': 45}
+        assert availability['available_periods'] == [
+            {'start': '2017-01-03T09:00:00Z', 'end': '2017-01-03T18:00:00Z'},
+            {'start': '2017-01-04T09:00:00Z', 'end': '2017-01-04T18:00:00Z'}
+        ]
+        assert availability['participants'] == [
+            {
+                'required': 1,
+                'members': [
+                    {'sub': 'acc_567236000909002'},
+                    {'sub': 'acc_678347111010113'}
+                ]
+            }
+        ]
+
+        assert payload['target_calendars'] == [
+            {
+                'sub': "acc_567236000909002",
+                'calendar_id': "cal_ABCDEF2ubSrL4a7x_aBCDE@f7mZzc2ufdgAciZvA",
+                'event': {
+                    'conferencing': {
+                        'profile_id': "integrated"
+                    }
+                },
+                'attendee': {
+                    'email': "support@cronofy.com",
+                    'display_name': "Marty McFly"
+                }
+            },
+            {
+                'sub': "acc_678347111010113",
+                'calendar_id': "cal_HIJKLM2ubSrL0a2e_lFGHI@f5mZzc6ufdgBciYvZ",
+                'event': {
+                    'conferencing': {
+                        'profile_id': "pro_ZYwjVpYOFWgx6eYl"
+                    }
+                },
+                'attendee': {
+                    'email': "support@cronofy.com",
+                    'display_name': "Doc Brown"
+                }
+            }
+        ]
+
+        assert payload['event'] == TEST_EVENT
+        assert payload['oauth'] == oauth
+        assert payload['minimum_notice'] == {'hours': 4}
+
+        assert payload['callback_url'] == 'http://www.example.com/callback'
+        assert payload['redirect_urls']['completed_url'] == 'http://www.example.com/completed'
+
+        assert payload['event_creation'] == "single"
+
+        assert request.headers['Authorization'] == "Bearer %s" % client.auth.client_secret
+
+        return (200, {}, json.dumps(REAL_TIME_SCHEDULING_RESPONSE))
+
+    responses.add_callback(
+        responses.POST,
+        url='%s/%s/real_time_scheduling' % (settings.API_BASE_URL, settings.API_VERSION),
+        callback=request_callback,
+        content_type='application/json',
+    )
+
+    periods = (
+        {'start': "2017-01-03T09:00:00Z", 'end': "2017-01-03T18:00:00Z"},
+        {'start': "2017-01-04T09:00:00Z", 'end': "2017-01-04T18:00:00Z"}
+    )
+    example_participants = ({
+        'members': [
+            "acc_567236000909002",
+            "acc_678347111010113",
+        ],
+        'required': 1
+    })
+
+    availability = {
+        'participants': example_participants,
+        'available_periods': periods,
+        'required_duration': 30,
+        'start_interval': 30,
+        'buffer': {
+            'before': 30,
+            'after': 45,
+        },
+    }
+
+    oauth = {
+        'scope': 'foo',
+        'redirect_uri': 'http://www.example.com',
+        'state': 'bar'
+    }
+
+    target_calendars = (
+        {
+            'sub': "acc_567236000909002",
+            'calendar_id': "cal_ABCDEF2ubSrL4a7x_aBCDE@f7mZzc2ufdgAciZvA",
+            'event': {
+                'conferencing': {
+                    'profile_id': "integrated"
+                }
+            },
+            'attendee': {
+                'email': "support@cronofy.com",
+                'display_name': "Marty McFly"
+            }
+        },
+        {
+            'sub': "acc_678347111010113",
+            'calendar_id': "cal_HIJKLM2ubSrL0a2e_lFGHI@f5mZzc6ufdgBciYvZ",
+            'event': {
+                'conferencing': {
+                    'profile_id': "pro_ZYwjVpYOFWgx6eYl"
+                }
+            },
+            'attendee': {
+                'email': "support@cronofy.com",
+                'display_name': "Doc Brown"
+            }
+        }
+    )
+
+    minimum_notice = {
+        'hours': 4
+    }
+
+    callback_url = 'http://www.example.com/callback'
+
+    redirect_urls = {
+        'completed_url': 'http://www.example.com/completed'
+    }
+
     event_creation = "single"
 
-    result = client.real_time_scheduling(availability, oauth, TEST_EVENT, [], minimum_notice, callback_url=callback_url, redirect_urls=redirect_urls, event_creation=event_creation)
+    result = client.real_time_scheduling(availability, oauth, TEST_EVENT, target_calendars, minimum_notice, callback_url=callback_url, redirect_urls=redirect_urls, event_creation=event_creation)
     assert result == REAL_TIME_SCHEDULING_RESPONSE
 
 


### PR DESCRIPTION
Support to accept [event_creation](https://docs.cronofy.com/developers/api/scheduling/real-time-scheduling/#param-event_creation) parameter for real_time_scheduling.

Extends test coverage for target_calendars.