### PR TITLE
Expand pytest coverage report with --cov-report=term-missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ pycronofy.set_request_hook(on_request)
 # Running the Unit Tests
 
 ```bash
-py.test pycronofy --cov=pycronofy
+py.test pycronofy --cov=pycronofy --cov-report=term-missing
 ```
 
 # Dependencies


### PR DESCRIPTION
Expands the coverage report provided by pytest-cov so that it includes the specific lines that are not covered by the tests.