### PR TITLE
Remove support for Python 3.7 and 3.8, add support for 3.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,16 +10,13 @@ jobs:
         python-version: ["3.7","3.8","3.9","3.10","3.11","3.12"]
 
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
+      - uses: actions/checkout@v5
 
-      - uses: actions/cache@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
         with:
-          path: ${{ env.pythonLocation }}
-          key: ${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-${{ hashFiles('**/requirements.txt') }}
+          cache: 'pip'
+          python-version: ${{ matrix.python-version }}
 
       - name: test application
         run: make test_ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7","3.8","3.9","3.10","3.11","3.12"]
+        python-version:
+          - "3.9"
+          - "3.10"
+          - "3.11"
+          - "3.12"
+          - "3.13"
 
     steps:
       - uses: actions/checkout@v5

--- a/pycronofy/datetime_utils.py
+++ b/pycronofy/datetime_utils.py
@@ -1,5 +1,4 @@
 import datetime
-import pytz
 
 from pycronofy.exceptions import PyCronofyDateTimeError
 
@@ -41,6 +40,6 @@ def format_event_time(date_time):
         error_message = 'Unsupported type: ``%s``.\nSupported types: ``<datetime.datetime>``, ``<datetime.date>``, ``<dict>``, or ``<str>``.'
         raise PyCronofyDateTimeError(
             error_message % (repr(type(date_time))), date_time)
-    if date_time.tzinfo and date_time.tzinfo != pytz.utc:
-        date_time = date_time.astimezone(pytz.utc)
+    if date_time.tzinfo and date_time.tzinfo != datetime.timezone.utc:
+        date_time = date_time.astimezone(datetime.timezone.utc)
     return date_time.strftime(ISO_8601_DATETIME_FORMAT)

--- a/pycronofy/tests/test_datetime_utils.py
+++ b/pycronofy/tests/test_datetime_utils.py
@@ -1,6 +1,6 @@
 import datetime
 import pytest
-import pytz
+import zoneinfo
 from pycronofy.datetime_utils import format_event_time
 
 
@@ -31,7 +31,7 @@ def test_iso8601_string_in_dict():
 
 def test_tz_aware_datetime_in_dict():
     """Test format_event_time returns an ISO8601 formatted date string in a dict when passed a datetimee object"""
-    date = datetime.datetime(2016, 1, 15, 14, 20, 15, tzinfo=pytz.timezone('EST'))
+    date = datetime.datetime(2016, 1, 15, 14, 20, 15, tzinfo=zoneinfo.ZoneInfo('EST'))
     params = {
         'time': date,
         'tzid': 'Etc/UTC',
@@ -60,7 +60,7 @@ def test_none():
 def test_tz_aware_datetime():
     """Test format_event_time returns an ISO8601 formatted datetime string with UTC timezone
     when passed a datetime.date object that's set to another timezone."""
-    d = datetime.datetime(2016, 1, 15, 14, 20, 15, tzinfo=pytz.timezone('EST'))
+    d = datetime.datetime(2016, 1, 15, 14, 20, 15, tzinfo=zoneinfo.ZoneInfo('EST'))
     assert format_event_time(d) == '2016-01-15T19:20:15Z'
 
 


### PR DESCRIPTION
This PR removes support for Python 3.7 and 3.8 and adds support for 3.13. Python 3.7 and 3.8 are no longer supported by Python.

This PR also updates GitHub Actions to the latest available versions. The current versions cannot be used anymore, and so tests fail immediately when using them.

Finally, it fixes an issue with timezone conversion when using `pytz`. These were the test failures we were getting:

```
=================================== FAILURES ===================================
________________________ test_tz_aware_datetime_in_dict ________________________

    def test_tz_aware_datetime_in_dict():
        """Test format_event_time returns an ISO8601 formatted date string in a dict when passed a datetimee object"""
        date = datetime.datetime(2016, 1, 15, 14, 20, 15, tzinfo=pytz.timezone('EST'))
        params = {
            'time': date,
            'tzid': 'Etc/UTC',
        }
>       assert format_event_time(params) == {'time': '2016-01-15T19:20:15Z', 'tzid': 'Etc/UTC'}
E       AssertionError: assert {'time': '2016-01-15T19:38:15Z', 'tzid': 'Etc/UTC'} == {'time': '2016-01-15T19:20:15Z', 'tzid': 'Etc/UTC'}
E         
E         Common items:
E         {'tzid': 'Etc/UTC'}
E         Differing items:
E         {'time': '2016-01-15T19:38:15Z'} != {'time': '2016-01-15T19:20:15Z'}
E         
E         Full diff:
E           {
E         -     'time': '2016-01-15T19:20:15Z',
E         ?                            ^^
E         +     'time': '2016-01-15T19:38:15Z',
E         ?                            ^^
E               'tzid': 'Etc/UTC',
E           }

pycronofy/tests/test_datetime_utils.py:39: AssertionError
____________________________ test_tz_aware_datetime ____________________________

    def test_tz_aware_datetime():
        """Test format_event_time returns an ISO8601 formatted datetime string with UTC timezone
        when passed a datetime.date object that's set to another timezone."""
        d = datetime.datetime(2016, 1, 15, 14, 20, 15, tzinfo=pytz.timezone('EST'))
>       assert format_event_time(d) == '2016-01-15T19:20:15Z'
E       AssertionError: assert '2016-01-15T19:38:15Z' == '2016-01-15T19:20:15Z'
E         
E         - 2016-01-15T19:20:15Z
E         ?               ^^
E         + 2016-01-15T19:38:15Z
E         ?               ^^

pycronofy/tests/test_datetime_utils.py:64: AssertionError
=============================== warnings summary ===============================
pycronofy/tests/test_real_time_scheduling.py::test_get_real_time_scheduling_status_by_token
  /opt/hostedtoolcache/Python/3.11.13/x64/lib/python3.11/site-packages/responses/__init__.py:436: DeprecationWarning: Argument 'match_querystring' is deprecated. Use 'responses.matchers.query_param_matcher' or 'responses.matchers.query_string_matcher'
    warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================ tests coverage ================================
_______________ coverage: platform linux, python 3.11.13-final-0 _______________

Name                           Stmts   Miss  Cover
--------------------------------------------------
pycronofy/__init__.py              7      1    86%
pycronofy/auth.py                 15      0   100%
pycronofy/batch.py                44      0   100%
pycronofy/client.py              339     24    93%
pycronofy/datetime_utils.py       23      0   100%
pycronofy/exceptions.py           31      0   100%
pycronofy/pagination.py           46      3    93%
pycronofy/request_handler.py      36      0   100%
pycronofy/settings.py              8      0   100%
pycronofy/validation.py           55      5    91%
--------------------------------------------------
TOTAL                            604     33    95%
=========================== short test summary info ============================
FAILED pycronofy/tests/test_datetime_utils.py::test_tz_aware_datetime_in_dict - AssertionError: assert {'time': '2016-01-15T19:38:15Z', 'tzid': 'Etc/UTC'} == {'time': '2016-01-15T19:20:15Z', 'tzid': 'Etc/UTC'}
  
  Common items:
  {'tzid': 'Etc/UTC'}
  Differing items:
  {'time': '2016-01-15T19:38:15Z'} != {'time': '2016-01-15T19:20:15Z'}
  
  Full diff:
    {
  -     'time': '2016-01-15T19:20:15Z',
  ?                            ^^
  +     'time': '2016-01-15T19:38:15Z',
  ?                            ^^
        'tzid': 'Etc/UTC',
    }
FAILED pycronofy/tests/test_datetime_utils.py::test_tz_aware_datetime - AssertionError: assert '2016-01-15T19:38:15Z' == '2016-01-15T19:20:15Z'
  
  - 2016-01-15T19:20:15Z
  ?               ^^
  + 2016-01-15T19:38:15Z
  ?               ^^
=================== 2 failed, 80 passed, 1 warning in 0.90s ====================
```

As you can see, changing the time from EST to UTC was adjusting the minutes rather than the hours. Switching to ZoneInfo resolved this. `ZoneInfo` was introduced in Python 3.9