### PR TITLE
Update GitHub Actions 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,19 +7,23 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7","3.8","3.9","3.10","3.11","3.12"]
+        python-version:
+          - "3.7"
+          - "3.8"
+          - "3.9"
+          - "3.10"
+          - "3.11"
+          - "3.12"
+          - "3.13"
 
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
+      - uses: actions/checkout@v5
 
-      - uses: actions/cache@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v6
         with:
-          path: ${{ env.pythonLocation }}
-          key: ${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-${{ hashFiles('**/requirements.txt') }}
+          cache: 'pip'
+          python-version: ${{ matrix.python-version }}
 
       - name: test application
         run: make test_ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,13 +3,31 @@ name: python CI
 on: [push]
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
+  build-legacy:
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         python-version:
           - "3.7"
           - "3.8"
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v6
+        with:
+          cache: 'pip'
+          python-version: ${{ matrix.python-version }}
+
+      - name: test application
+        run: make test_ci
+
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version:
           - "3.9"
           - "3.10"
           - "3.11"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,10 +6,10 @@ jobs:
   build-legacy:
     runs-on: ubuntu-22.04
     strategy:
+      fail-fast: false
       matrix:
         python-version:
           - "3.7"
-          - "3.8"
 
     steps:
       - uses: actions/checkout@v5
@@ -26,8 +26,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version:
+          - "3.8"
           - "3.9"
           - "3.10"
           - "3.11"


### PR DESCRIPTION
The current version of GitHub Actions no longer work. This PR fixes that by:
- Updating GitHub Actions to the latest versions
- Running the Python 3.7 CI on an older version of Ubuntu as it isn't supported on the latest (24.04)