### PR TITLE
Replace pytz

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [2.1.0]
+* Replaced `pytz` with the standard library `datetime.timezone.utc` and `zoneinfo` modules; `pytz` is no longer a dependency [#116]
+
 ## [2.0.7]
 * Added support for the `response_format` parameter to the `real_time_scheduling` query API [#108]
 
@@ -38,6 +41,7 @@
 ## [1.9.3]
 * Add support for Element Token generation [#70]
 
+[2.1.0]: https://github.com/cronofy/pycronofy/releases/tag/2.1.0
 [2.0.7]: https://github.com/cronofy/pycronofy/releases/tag/2.0.7
 [2.0.6]: https://github.com/cronofy/pycronofy/releases/tag/2.0.6
 [2.0.5]: https://github.com/cronofy/pycronofy/releases/tag/2.0.5
@@ -51,6 +55,7 @@
 [1.9.4]: https://github.com/cronofy/pycronofy/releases/tag/1.9.4
 [1.9.3]: https://github.com/cronofy/pycronofy/releases/tag/1.9.3
 
+[#116]: https://github.com/cronofy/pycronofy/pull/116
 [#108]: https://github.com/cronofy/pycronofy/pull/108
 [#107]: https://github.com/cronofy/pycronofy/pull/107
 [#105]: https://github.com/cronofy/pycronofy/pull/105

--- a/PKG-INFO
+++ b/PKG-INFO
@@ -1,6 +1,6 @@
 Metadata-Version: 1.0
 Name: pycronofy
-Version: 2.0.7
+Version: 2.1.0
 Summary: Python wrapper for Cronofy
 Home-page: https://github.com/cronofy/pycronofy
 Author: VenueBook

--- a/pycronofy/__init__.py
+++ b/pycronofy/__init__.py
@@ -1,6 +1,6 @@
 from pycronofy.client import Client  # noqa: F401
 from pycronofy import settings
-__version__ = '2.0.7'
+__version__ = '2.1.0'
 __name__ = 'PyCronofy'
 
 """

--- a/pycronofy/client.py
+++ b/pycronofy/client.py
@@ -5,8 +5,6 @@ import hashlib
 import base64
 import hmac
 
-import pytz
-
 from pycronofy import settings
 from pycronofy.auth import Auth
 from pycronofy.batch import BatchEntry
@@ -281,7 +279,7 @@ class Client(object):
                 'redirect_uri': redirect_uri if redirect_uri else self.auth.redirect_uri,
             })
         data = response.json()
-        token_expiration = (datetime.datetime.now(tz=pytz.utc) + datetime.timedelta(seconds=data['expires_in']))
+        token_expiration = (datetime.datetime.now(tz=datetime.timezone.utc) + datetime.timedelta(seconds=data['expires_in']))
         self.auth.update(
             token_expiration=token_expiration,
             access_token=data['access_token'],
@@ -308,7 +306,7 @@ class Client(object):
                 'application_calendar_id': application_calendar_id,
             })
         data = response.json()
-        token_expiration = (datetime.datetime.now(tz=pytz.utc) + datetime.timedelta(seconds=data['expires_in']))
+        token_expiration = (datetime.datetime.now(tz=datetime.timezone.utc) + datetime.timedelta(seconds=data['expires_in']))
         self.auth.update(
             token_expiration=token_expiration,
             access_token=data['access_token'],
@@ -330,7 +328,7 @@ class Client(object):
         """
         if not self.auth.token_expiration:
             return True
-        return datetime.datetime.now(tz=pytz.utc) > self.auth.token_expiration
+        return datetime.datetime.now(tz=datetime.timezone.utc) > self.auth.token_expiration
 
     def list_calendars(self):
         """Return a list of calendars available for the active account.
@@ -538,7 +536,7 @@ class Client(object):
             }
         )
         data = response.json()
-        token_expiration = (datetime.datetime.now(tz=pytz.utc) + datetime.timedelta(seconds=data['expires_in']))
+        token_expiration = (datetime.datetime.now(tz=datetime.timezone.utc) + datetime.timedelta(seconds=data['expires_in']))
         self.auth.update(
             token_expiration=token_expiration,
             access_token=data['access_token'],

--- a/pycronofy/datetime_utils.py
+++ b/pycronofy/datetime_utils.py
@@ -1,5 +1,4 @@
 import datetime
-import pytz
 
 from pycronofy.exceptions import PyCronofyDateTimeError
 
@@ -41,6 +40,6 @@ def format_event_time(date_time):
         error_message = 'Unsupported type: ``%s``.\nSupported types: ``<datetime.datetime>``, ``<datetime.date>``, ``<dict>``, or ``<str>``.'
         raise PyCronofyDateTimeError(
             error_message % (repr(type(date_time))), date_time)
-    if date_time.tzinfo and date_time.tzinfo != pytz.utc:
-        date_time = date_time.astimezone(pytz.utc)
+    if date_time.tzinfo and date_time.tzinfo != datetime.timezone.utc:
+        date_time = date_time.astimezone(datetime.timezone.utc)
     return date_time.strftime(ISO_8601_DATETIME_FORMAT)

--- a/pycronofy/tests/test_batch.py
+++ b/pycronofy/tests/test_batch.py
@@ -2,7 +2,6 @@ import datetime
 import json
 
 import pytest
-import pytz
 import responses
 
 from pycronofy import Client
@@ -140,8 +139,8 @@ def test_batch_upsert_with_datetimes(client):
         'event_id': 'test-1',
         'summary': 'Test Event',
         'description': 'Talk about how awesome dogs are.',
-        'start': datetime.datetime(2022, 3, 22, 17, tzinfo=pytz.utc),
-        'end': datetime.datetime(2022, 3, 22, 18, tzinfo=pytz.utc),
+        'start': datetime.datetime(2022, 3, 22, 17, tzinfo=datetime.timezone.utc),
+        'end': datetime.datetime(2022, 3, 22, 18, tzinfo=datetime.timezone.utc),
         'tzid': 'Etc/UTC',
         'location': {
             'description': 'Location!',

--- a/pycronofy/tests/test_client.py
+++ b/pycronofy/tests/test_client.py
@@ -1,7 +1,6 @@
 import datetime
 import json
 import pytest
-import pytz
 import responses
 
 from functools import partial
@@ -336,9 +335,9 @@ def test_is_authorization_expired(client):
 
     :param Client client: Client instance with test data.
     """
-    client.auth.token_expiration = datetime.datetime.now(tz=pytz.utc) + datetime.timedelta(seconds=60)
+    client.auth.token_expiration = datetime.datetime.now(tz=datetime.timezone.utc) + datetime.timedelta(seconds=60)
     assert client.is_authorization_expired() is False
-    client.auth.token_expiration = datetime.datetime.now(tz=pytz.utc) - datetime.timedelta(seconds=60)
+    client.auth.token_expiration = datetime.datetime.now(tz=datetime.timezone.utc) - datetime.timedelta(seconds=60)
     assert client.is_authorization_expired() is True
 
 

--- a/pycronofy/tests/test_datetime_utils.py
+++ b/pycronofy/tests/test_datetime_utils.py
@@ -1,6 +1,9 @@
 import datetime
 import pytest
-import pytz
+try:
+    import zoneinfo
+except ImportError:
+    from backports import zoneinfo
 from pycronofy.datetime_utils import format_event_time
 
 
@@ -31,7 +34,7 @@ def test_iso8601_string_in_dict():
 
 def test_tz_aware_datetime_in_dict():
     """Test format_event_time returns an ISO8601 formatted date string in a dict when passed a datetimee object"""
-    date = datetime.datetime(2016, 1, 15, 14, 20, 15, tzinfo=pytz.timezone('EST'))
+    date = datetime.datetime(2016, 1, 15, 14, 20, 15, tzinfo=zoneinfo.ZoneInfo('EST'))
     params = {
         'time': date,
         'tzid': 'Etc/UTC',
@@ -60,7 +63,7 @@ def test_none():
 def test_tz_aware_datetime():
     """Test format_event_time returns an ISO8601 formatted datetime string with UTC timezone
     when passed a datetime.date object that's set to another timezone."""
-    d = datetime.datetime(2016, 1, 15, 14, 20, 15, tzinfo=pytz.timezone('EST'))
+    d = datetime.datetime(2016, 1, 15, 14, 20, 15, tzinfo=zoneinfo.ZoneInfo('EST'))
     assert format_event_time(d) == '2016-01-15T19:20:15Z'
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,6 @@ dynamic = ["version"]
 requires-python = ">=3.7"
 dependencies = [
     "requests>=2.20.0",
-    "pytz>=2013.7",
 ]
 description = 'Python library for Cronofy'
 authors = [

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -1,5 +1,5 @@
 requests>=2.21.0
-pytz>=2018.9
+backports.zoneinfo>=0.2.1 ; python_version < "3.9"
 
 pytest
 pytest-cov

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 requests>=2.21.0
-pytz>=2018.9
 
 pytest>=6.2.4
 pytest-cov>=4.1


### PR DESCRIPTION
The `pytz` module is currently causing issues with converting date times between timezones. You can see this in the failing tests on recent PRs such as https://github.com/cronofy/pycronofy/pull/115.

This PR replaces using this module with the built-in `datetime` module, the built-in `zoneinfo` module for Python >= 3.9, or a backport of `zoneinfo` for Python < 3.9. As you can see from the tests on this PR, these changes resolve this issue with failing tests.

Rather than just fixing the tests, I have replaced any usage of `pytz` so that we can also remove it as a dependency.